### PR TITLE
refactor: プレイ中からカスタムステータスに変更した

### DIFF
--- a/main.py
+++ b/main.py
@@ -140,7 +140,7 @@ async def on_ready():
     print("ログイン成功")
     update_guilds()
     initialize()
-    await client.change_presence(activity = discord.Activity(name=str(GLOBAL_SETTINGS["PLAYING"]), type=discord.ActivityType.playing))
+    await client.change_presence(activity=discord.CustomActivity(name=str(GLOBAL_SETTINGS["PLAYING"])))
     await commandTree.sync()
 
 @client.event
@@ -214,7 +214,7 @@ async def invite_command(interaction: discord.Interaction):
 async def suteme_command(interaction: discord.Interaction, status: str):
     if(is_mod(interaction.user)):
         GLOBAL_SETTINGS["PLAYING"] = status
-        await client.change_presence(activity = discord.Activity(name=str(GLOBAL_SETTINGS["PLAYING"]), type=discord.ActivityType.playing))
+        await client.change_presence(activity=discord.CustomActivity(name=str(GLOBAL_SETTINGS["PLAYING"])))
         await interaction.response.send_message(f'ステータスを`{GLOBAL_SETTINGS["PLAYING"]}`に変更しました')
         save.global_settings()
     else:


### PR DESCRIPTION
GLOBAL_SETTINGS["PLAYING"]をそのままカスタムステータスとして扱った。
Discord.pyのバージョンによっては動作しない可能性がある。
`pip install --upgrade discord.py`を実行すること。